### PR TITLE
csproj-29 add unit tests for factory methods in ManagedObject

### DIFF
--- a/src/Decorators/ManagedObject.cs
+++ b/src/Decorators/ManagedObject.cs
@@ -91,7 +91,7 @@ public sealed class ManagedObject<T> : IManagedObject<T>
         (HasValue, Value) = (true, value);
     }
 
-    public void ResetWithNewValueIfNotNull(T? value)
+    public void ResetAndReplaceIfNotNull(T? value)
     {
         Reset();
         if (value is not null)


### PR DESCRIPTION
Closes #29

## Changes
- additional tests for ```FromNullable```
- added tests for renamed ```ResetAndReplaceIfNotNull``` (renamed)
- added tests for ```ReleaseOrThrow()```

## Tests

- ✅ CI Build
- ✅ Unit tests
- ✅ Manual Tests
